### PR TITLE
Gas free transactions

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -354,6 +354,10 @@ var (
 		Usage: "Duration for announcing local pending transactions again (default = 10 years, minimum = 1 minute)",
 		Value: ethconfig.Defaults.TxPool.ReannounceTime,
 	}
+	TxPoolGasFreeContracts = cli.DurationFlag{
+		Name:  "txpool.gasfreecontracts",
+		Usage: "Comma delimited list of the gas free smart contracts",
+	}
 	// Performance tuning settings
 	CacheFlag = cli.IntFlag{
 		Name:  "cache",
@@ -1326,6 +1330,16 @@ func setTxPool(ctx *cli.Context, cfg *core.TxPoolConfig) {
 	}
 	if ctx.GlobalIsSet(TxPoolReannounceTimeFlag.Name) {
 		cfg.ReannounceTime = ctx.GlobalDuration(TxPoolReannounceTimeFlag.Name)
+	}
+	if ctx.GlobalIsSet(TxPoolGasFreeContracts.Name) {
+		cfg.GasFreeContracts = make(map[common.Address]bool)
+		for _, rawAddress := range ctx.GlobalStringSlice(TxPoolGasFreeContracts.Name) {
+			address := common.HexToAddress(rawAddress)
+			if address == (common.Address{}) {
+				Fatalf("Unable to parse address for the [%s], failed on address (%s)", TxPoolGasFreeContracts.Name, rawAddress)
+			}
+			cfg.GasFreeContracts[address] = true
+		}
 	}
 }
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -158,6 +158,8 @@ type TxPoolConfig struct {
 
 	Lifetime       time.Duration // Maximum amount of time non-executable transaction are queued
 	ReannounceTime time.Duration // Duration for announcing local pending transactions again
+
+	GasFreeContracts map[common.Address]bool
 }
 
 // DefaultTxPoolConfig contains the default configurations for the transaction
@@ -592,7 +594,8 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrInvalidSender
 	}
 	// Drop non-local transactions under our own minimal accepted gas price
-	if !local && tx.GasPriceIntCmp(pool.gasPrice) < 0 {
+	isGasFree := pool.config.GasFreeContracts != nil && pool.config.GasFreeContracts[*tx.To()]
+	if !local && tx.GasPriceIntCmp(pool.gasPrice) < 0 && !isGasFree {
 		return ErrUnderpriced
 	}
 	// Ensure the transaction adheres to nonce ordering


### PR DESCRIPTION
Added special flag for the txpool that allows to make some transactions to be from paying gas at all. It might be useful for the initialising the chain when there is no native tokens distributed between holders.