### PR TITLE
Debug api blockwards

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -145,4 +145,6 @@ type PoSA interface {
 	EnoughDistance(chain ChainReader, header *types.Header) bool
 	IsLocalBlock(header *types.Header) bool
 	AllowLightProcess(chain ChainReader, currentHeader *types.Header) bool
+
+	BlockRewards(blockNumber *big.Int) *big.Int
 }

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1066,35 +1066,37 @@ func (p *Parlia) distributeIncoming(val common.Address, state *state.StateDB, he
 	txs *[]*types.Transaction, receipts *[]*types.Receipt, receivedTxs *[]*types.Transaction, usedGas *uint64, mining bool) error {
 	coinbase := header.Coinbase
 	balance := state.GetBalance(consensus.SystemAddress)
-	if balance.Cmp(common.Big0) <= 0 {
-		return nil
-	}
 	state.SetBalance(consensus.SystemAddress, big.NewInt(0))
 	state.AddBalance(coinbase, balance)
-
+	rewards := big.NewInt(0).Abs(balance)
 	if rules := p.chainConfig.Rules(header.Number); rules.HasBlockRewards {
 		blockRewards := p.chainConfig.Parlia.BlockRewards
 		// if we have enabled block rewards and rewards are greater than 0 then
 		if blockRewards != nil && blockRewards.Cmp(common.Big0) > 0 {
 			state.AddBalance(coinbase, blockRewards)
+			rewards = rewards.Add(rewards, blockRewards)
 		}
 	}
-
-	doDistributeSysReward := state.GetBalance(common.HexToAddress(systemcontract.SystemRewardContract)).Cmp(maxSystemBalance) < 0
-	if doDistributeSysReward {
-		var rewards = new(big.Int)
-		rewards = rewards.Rsh(balance, systemRewardPercent)
-		if rewards.Cmp(common.Big0) > 0 {
-			err := p.distributeToSystem(rewards, state, header, chain, txs, receipts, receivedTxs, usedGas, mining)
-			if err != nil {
-				return err
+	if rewards.Cmp(common.Big0) <= 0 {
+		return nil
+	}
+	if balance.Cmp(common.Big0) > 0 {
+		doDistributeSysReward := state.GetBalance(common.HexToAddress(systemcontract.SystemRewardContract)).Cmp(maxSystemBalance) < 0
+		if doDistributeSysReward {
+			var SysRewards = new(big.Int)
+			SysRewards = SysRewards.Rsh(balance, systemRewardPercent)
+			if SysRewards.Cmp(common.Big0) > 0 {
+				err := p.distributeToSystem(SysRewards, state, header, chain, txs, receipts, receivedTxs, usedGas, mining)
+				if err != nil {
+					return err
+				}
+				log.Trace("distribute to system reward pool", "block hash", header.Hash(), "amount", SysRewards)
+				rewards = rewards.Sub(rewards, SysRewards)
 			}
-			log.Trace("distribute to system reward pool", "block hash", header.Hash(), "amount", rewards)
-			balance = balance.Sub(balance, rewards)
 		}
 	}
-	log.Trace("distribute to validator contract", "block hash", header.Hash(), "amount", balance)
-	return p.distributeToValidator(balance, val, state, header, chain, txs, receipts, receivedTxs, usedGas, mining)
+	log.Trace("distribute to validator contract", "block hash", header.Hash(), "amount", rewards)
+	return p.distributeToValidator(rewards, val, state, header, chain, txs, receipts, receivedTxs, usedGas, mining)
 }
 
 // slash spoiled validators

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1051,6 +1051,15 @@ func (p *Parlia) getCurrentValidators(blockHash common.Hash) ([]common.Address, 
 	}
 	return valz, nil
 }
+func (p *Parlia) BlockRewards(blockNumber *big.Int) *big.Int {
+	if rules := p.chainConfig.Rules(blockNumber); rules.HasBlockRewards {
+		blockRewards := p.chainConfig.Parlia.BlockRewards
+		if blockRewards != nil && blockRewards.Cmp(common.Big0) > 0 {
+			return blockRewards
+		}
+	}
+	return nil
+}
 
 // slash spoiled validators
 func (p *Parlia) distributeIncoming(val common.Address, state *state.StateDB, header *types.Header, chain core.ChainContext,

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1083,15 +1083,15 @@ func (p *Parlia) distributeIncoming(val common.Address, state *state.StateDB, he
 	if balance.Cmp(common.Big0) > 0 {
 		doDistributeSysReward := state.GetBalance(common.HexToAddress(systemcontract.SystemRewardContract)).Cmp(maxSystemBalance) < 0
 		if doDistributeSysReward {
-			var SysRewards = new(big.Int)
-			SysRewards = SysRewards.Rsh(balance, systemRewardPercent)
-			if SysRewards.Cmp(common.Big0) > 0 {
-				err := p.distributeToSystem(SysRewards, state, header, chain, txs, receipts, receivedTxs, usedGas, mining)
+			var sysRewards = new(big.Int)
+			sysRewards = sysRewards.Rsh(balance, systemRewardPercent)
+			if sysRewards.Cmp(common.Big0) > 0 {
+				err := p.distributeToSystem(sysRewards, state, header, chain, txs, receipts, receivedTxs, usedGas, mining)
 				if err != nil {
 					return err
 				}
-				log.Trace("distribute to system reward pool", "block hash", header.Hash(), "amount", SysRewards)
-				rewards = rewards.Sub(rewards, SysRewards)
+				log.Trace("distribute to system reward pool", "block hash", header.Hash(), "amount", sysRewards)
+				rewards = rewards.Sub(rewards, sysRewards)
 			}
 		}
 	}

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -200,12 +200,10 @@ func (eth *Ethereum) stateAtTransaction(block *types.Block, txIndex int, reexec 
 			if balance.Cmp(common.Big0) > 0 {
 				statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
 				statedb.AddBalance(context.Coinbase, balance)
-				//todo
-				statedb.AddBalance(context.Coinbase, big.NewInt(5000000000000000000))
-
-				balance := statedb.GetBalance(context.Coinbase)
-				log.Info("debug_traceBlockByNumber", "context.Coinbase", context.Coinbase.Hex(), "Balance", balance)
-
+			}
+			blockRewards := posa.BlockRewards(block.Header().Number)
+			if blockRewards != nil {
+				statedb.AddBalance(context.Coinbase, blockRewards)
 			}
 		}
 		statedb.Prepare(tx.Hash(), block.Hash(), idx)

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -200,6 +200,12 @@ func (eth *Ethereum) stateAtTransaction(block *types.Block, txIndex int, reexec 
 			if balance.Cmp(common.Big0) > 0 {
 				statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
 				statedb.AddBalance(context.Coinbase, balance)
+				//todo
+				statedb.AddBalance(context.Coinbase, big.NewInt(5000000000000000000))
+
+				balance := statedb.GetBalance(context.Coinbase)
+				log.Info("debug_traceBlockByNumber", "context.Coinbase", context.Coinbase.Hex(), "Balance", balance)
+
 			}
 		}
 		statedb.Prepare(tx.Hash(), block.Hash(), idx)

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -536,10 +536,14 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 		if posa, ok := api.backend.Engine().(consensus.PoSA); ok {
 			if isSystem, _ := posa.IsSystemTransaction(tx, block.Header()); isSystem {
 				balance := statedb.GetBalance(consensus.SystemAddress)
-				if balance.Cmp(common.Big0) > 0 {
-					statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
-					statedb.AddBalance(vmctx.Coinbase, balance)
-				}
+				//if balance.Cmp(common.Big0) > 0 {
+				statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
+				statedb.AddBalance(vmctx.Coinbase, balance)
+				//todo
+				statedb.AddBalance(vmctx.Coinbase, big.NewInt(5000000000000000000))
+				balance = statedb.GetBalance(vmctx.Coinbase)
+				log.Info("debug_traceBlockByNumber", "context.Coinbase", vmctx.Coinbase.Hex(), "Balance", balance)
+				//}
 			}
 		}
 
@@ -644,10 +648,15 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		if posa, ok := api.backend.Engine().(consensus.PoSA); ok {
 			if isSystem, _ := posa.IsSystemTransaction(tx, block.Header()); isSystem {
 				balance := statedb.GetBalance(consensus.SystemAddress)
-				if balance.Cmp(common.Big0) > 0 {
-					statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
-					statedb.AddBalance(block.Header().Coinbase, balance)
-				}
+				//if balance.Cmp(common.Big0) > 0 {
+				statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
+				statedb.AddBalance(block.Header().Coinbase, balance)
+				//todo
+				statedb.AddBalance(block.Header().Coinbase, big.NewInt(5000000000000000000))
+
+				balance = statedb.GetBalance(block.Header().Coinbase)
+				log.Info("debug_traceBlockByNumber", "context.Coinbase", block.Header().Coinbase.Hex(), "Balance", balance)
+				//	}
 			}
 		}
 
@@ -768,10 +777,14 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		if posa, ok := api.backend.Engine().(consensus.PoSA); ok {
 			if isSystem, _ := posa.IsSystemTransaction(tx, block.Header()); isSystem {
 				balance := statedb.GetBalance(consensus.SystemAddress)
-				if balance.Cmp(common.Big0) > 0 {
-					statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
-					statedb.AddBalance(vmctx.Coinbase, balance)
-				}
+				//	if balance.Cmp(common.Big0) > 0 {
+				statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
+				statedb.AddBalance(vmctx.Coinbase, balance)
+				//todo
+				statedb.AddBalance(vmctx.Coinbase, big.NewInt(5000000000000000000))
+				balance = statedb.GetBalance(vmctx.Coinbase)
+				log.Info("debug_traceBlockByNumber", "context.Coinbase", vmctx.Coinbase.Hex(), "Balance", balance)
+				//	}
 			}
 		}
 		statedb.Prepare(tx.Hash(), block.Hash(), i)
@@ -934,10 +947,15 @@ func (api *API) traceTx(ctx context.Context, message core.Message, txctx *Contex
 	if posa, ok := api.backend.Engine().(consensus.PoSA); ok && message.From() == vmctx.Coinbase &&
 		posa.IsSystemContract(message.To()) && message.GasPrice().Cmp(big.NewInt(0)) == 0 {
 		balance := statedb.GetBalance(consensus.SystemAddress)
-		if balance.Cmp(common.Big0) > 0 {
-			statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
-			statedb.AddBalance(vmctx.Coinbase, balance)
-		}
+		//	if balance.Cmp(common.Big0) > 0 {
+		statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
+		statedb.AddBalance(vmctx.Coinbase, balance)
+		//todo
+		statedb.AddBalance(vmctx.Coinbase, big.NewInt(5000000000000000000))
+		balance = statedb.GetBalance(vmctx.Coinbase)
+		log.Info("debug_traceBlockByNumber", "vmctx.Coinbase", vmctx.Coinbase.Hex(), "Balance", balance)
+
+		//	}
 	}
 
 	// Call Prepare to clear out the statedb access list

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1233,6 +1233,10 @@ func (s *PublicBlockChainAPI) replay(ctx context.Context, block *types.Block, ac
 					statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
 					statedb.AddBalance(block.Header().Coinbase, balance)
 				}
+				blockRewards := posa.BlockRewards(block.Header().Number)
+				if blockRewards != nil {
+					statedb.AddBalance(context.Coinbase, blockRewards)
+				}
 			}
 		}
 


### PR DESCRIPTION
If you start the function of block rewards. Regardless of whether there is gas fee or not, each block will cast fixed block rewards. At this time, we need to modify Parlia.go::distributeIncoming . In this way, a reasonable casting demand can be met. However, when accessing the interface of debug_traceBlockByNumber, an error will be reported, indicating that the account balance is insufficient.

Error example:

curl --request POST \
   --url http://127.0.0.1:8545/ \
   --header 'Content-Type: application/json' \
   --data '{"jsonrpc":"2.0","id":1,"method":"debug_traceBlockByNumber","params":["latest"]}'

Return result:

{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"insufficient funds for transfer: address 0xe016D750D86bb7B5B9c1eB2a5b8E4EA4e292Ed87"}}
